### PR TITLE
Hide endscreen content

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ YouTube Liberation works by hiding elements that lead you towards new content yo
 - The entire home page of alg-generated recommendations
 - Video recommendations on watch pages
 - Comments sections on watch pages
+- Endscreen recommendations
 - Extraneous UI elements, replacing the full sidebar with a much more minimal one and removing most topbar buttons
 
 YouTube liberation does not at all compromise:

--- a/content.js
+++ b/content.js
@@ -66,7 +66,8 @@ if (home != null) {
 chrome.storage.sync.get({
     comments: false,
     notifications: false,
-    upload: false
+    upload: false,
+    endscreen: false,
 }, function (settings) {    
     if (settings.upload){
         addShow("#buttons ytd-topbar-menu-button-renderer:nth-of-type(1)");
@@ -78,6 +79,12 @@ chrome.storage.sync.get({
     
     if (settings.comments){
         addShow("ytd-comments#comments");
+    }
+    
+    if (!settings.endscreen) {
+        document.arrive(".ytp-endscreen-content", function (endscreen) {
+            endscreen.style.display = "none"
+        })
     }
 });
 

--- a/popup.html
+++ b/popup.html
@@ -99,6 +99,7 @@
                 <label for='comments'><input type='checkbox' id='comments' name='comments'></input>Show comments on watch page</label>
                 <label for='notifications'><input type='checkbox' id='notifications' name='notifications'></input>Show notifications button</label>
                 <label for='upload'><input type='checkbox' id='upload' name='upload'></input>Show upload button</label>
+                <label for='endscreen'><input type='checkbox' id='endscreen' name='endscreen'></input>Show endscreen recommendations</label>
                 <input type='button' id='options-save' value='Save'></input>
             </form>
             <div class='status'><span id='status'></span></div>

--- a/popup.js
+++ b/popup.js
@@ -2,7 +2,7 @@ function save_options() {
     comments = document.getElementById('comments').checked;
     notifications = document.getElementById('notifications').checked;
     upload = document.getElementById('upload').checked;
-	endscreen = document.getElementById('endscreen').checked;
+    endscreen = document.getElementById('endscreen').checked;
 
     chrome.storage.sync.set({
         comments: comments,

--- a/popup.js
+++ b/popup.js
@@ -2,11 +2,13 @@ function save_options() {
     comments = document.getElementById('comments').checked;
     notifications = document.getElementById('notifications').checked;
     upload = document.getElementById('upload').checked;
+	endscreen = document.getElementById('endscreen').checked;
 
     chrome.storage.sync.set({
         comments: comments,
         notifications: notifications,
-        upload: upload
+        upload: upload,
+        endscreen: endscreen,
     }, function(){
         statusInd = document.getElementById("status");
         statusInd.innerText = 'Options saved! Reload for them to take effect';
@@ -20,11 +22,13 @@ function restore_options() {
     chrome.storage.sync.get({
         comments: false,
         notifications: false,
-        upload: false
+        upload: false,
+        endscreen: false,
     }, function (items) {
         document.getElementById('comments').checked = items.comments;
         document.getElementById('notifications').checked = items.notifications;
         document.getElementById('upload').checked = items.upload;
+        document.getElementById('endscreen').checked = items.endscreen;
     });
 }
 


### PR DESCRIPTION
I like the extension the most because it removes everything from YouTube that I didn't ask it to show me.  
Recently, I unexpectedly saw a recommendation, there was a spoiler for the new movie in the preview.  
I think it would be nice to hide the generated endscreen recommendations, which appear at the end of the video.  

**Before:**
![before](https://user-images.githubusercontent.com/40423143/147381421-1b957374-eeed-45f1-97ac-c05062c07d2c.png)  

**After:**
![after](https://user-images.githubusercontent.com/40423143/147381417-b4948fae-c23e-44b2-8359-2ace6b89b1c3.png)

They are hidden by default, but I added an option to the popup window to change that behavior.

![popup](https://user-images.githubusercontent.com/40423143/147381539-cf07c7da-ddcf-407a-881b-7d30acf10e23.png)

This doesn't seem to affect other things like autoplay/playlists. Please consider this feature.

